### PR TITLE
Migrate to rust-0.11

### DIFF
--- a/src/libini/ini.rs
+++ b/src/libini/ini.rs
@@ -1,21 +1,19 @@
-extern mod extra;
-use std::hashmap::HashMap;
-use std::hashmap::{HashMapIterator, HashMapMutIterator};
-use std::path::Path;
-use std::rt::io::*;
-use std::cast::transmute;
+use std::collections::hashmap::HashMap;
+use std::collections::hashmap::{Entries, MutEntries};
+use std::io::*;
+use std::mem::transmute;
 use std::char;
 use std::num::from_str_radix;
 use std::str;
 
-fn escape_str(s: &str) -> ~str {
-    let mut escaped = ~"";
-    for c in s.iter() {
+fn escape_str(s: &str) -> String {
+    let mut escaped: String = "".to_string();
+    for c in s.chars() {
         match c {
             '\\' => escaped.push_str("\\\\"),
             '\0' => escaped.push_str("\\0"),
             '\x01' .. '\x06' | '\x0E' .. '\x1F' | '\x7F' .. '\xFF'
-                => escaped.push_str(format!("\\\\x{:04x}", c as int)),
+                => escaped.push_str(format!("\\\\x{:04x}", c as int).as_slice()),
             '\x07' => escaped.push_str("\\a"),
             '\x08' => escaped.push_str("\\b"),
             '\x0c' => escaped.push_str("\\f"),
@@ -28,7 +26,7 @@ fn escape_str(s: &str) -> ~str {
             '=' => escaped.push_str("\\="),
             ':' => escaped.push_str("\\:"),
             '\u0080' .. '\uFFFF'
-                => escaped.push_str(format!("\\\\x{:04x}", c as int)),
+                => escaped.push_str(format!("\\\\x{:04x}", c as int).as_slice()),
             _ => escaped.push_char(c)
         }
     }
@@ -36,33 +34,33 @@ fn escape_str(s: &str) -> ~str {
 }
 
 pub struct Ini {
-    priv sections: HashMap<~str, Properties>,
-    priv cur_section: ~str,
-    default_key: ~str,
+    sections: HashMap<String, Properties>,
+    cur_section: String,
+    pub default_key: String,
 }
 
-type Properties = HashMap<~str, ~str>; // Key-value pairs
+pub type Properties = HashMap<String, String>; // Key-value pairs
 
-impl<'self> Ini {
+impl<'a> Ini {
     pub fn new() -> Ini {
         Ini {
             sections: HashMap::new(),
-            cur_section: ~"@General",
-            default_key: ~"@General",
+            cur_section: "@General".to_string(),
+            default_key: "@General".to_string(),
         }
     }
 
-    pub fn begin_section(&'self mut self, section: ~str) -> &'self mut Ini {
+    pub fn begin_section(&'a mut self, section: String) -> &'a mut Ini {
         self.cur_section = section.clone();
         self
     }
 
-    pub fn end_section(&'self mut self) -> &'self mut Ini {
+    pub fn end_section(&'a mut self) -> &'a mut Ini {
         self.cur_section = self.default_key.clone();
         self
     }
 
-    pub fn set(&'self mut self, key: ~str, value: ~str) -> &'self mut Ini {
+    pub fn set(&'a mut self, key: String, value: String) -> &'a mut Ini {
         {
             let dat = self.sections.find_or_insert(self.cur_section.clone(), HashMap::new());
             dat.insert_or_update_with(key, value, |_,_| {});
@@ -70,17 +68,18 @@ impl<'self> Ini {
         self
     }
 
-    pub fn get(&'self self, key: ~str) -> &'self ~str {
+    pub fn get(&'a self, key: String) -> &'a String {
         let cursec = &self.cur_section;
-        let cursec_map: &'self Properties = self.sections.get(cursec);
+        let cursec_map: &'a Properties = self.sections.get(cursec);
         cursec_map.get(&key)
     }
 }
 
-impl<'self> Ini {
-    pub fn write_file(&'self self, filename: &str) -> &'self Ini {
+impl<'a> Ini {
+    #[allow(unused_must_use)]
+    pub fn write_file(&'a self, filename: &str) -> &'a Ini {
         let mut firstline = true;
-        let mut file = file::open(&Path(filename), CreateOrTruncate, Write).unwrap();
+        let mut file = File::open_mode(&Path::new(filename), Truncate, Write).unwrap();
         for (section, props) in self.sections.iter() {
             if firstline {
                 firstline = false;
@@ -88,11 +87,11 @@ impl<'self> Ini {
             else {
                 file.write("\n".as_bytes());
             }
-            let section_str = format!("[{:s}]\n", escape_str(*section));
-            file.write(section_str.as_bytes());
+            let section_str = format!("[{:s}]\n", escape_str(section.as_slice()));
+            file.write(section_str.as_slice().as_bytes());
             for (k, v) in props.iter() {
-                let k_str = escape_str(*k);
-                let v_str = escape_str(*v);
+                let k_str = escape_str(k.as_slice());
+                let v_str = escape_str(v.as_slice());
                 let prop_str = format!("{:s}={:s}\n", k_str, v_str);
                 file.write(prop_str.as_bytes());
             }
@@ -103,20 +102,20 @@ impl<'self> Ini {
 }
 
 struct Parser<T> {
-    priv ch: char,
-    priv rdr: ~T,
-    priv line: uint,
-    priv col: uint,
+    ch: char,
+    rdr: Box<T>,
+    line: uint,
+    col: uint,
 }
 
 struct Error {
     line: uint,
     col: uint,
-    msg: ~str,
+    msg: String,
 }
 
 impl<T: Iterator<char>> Parser<T> {
-    fn new(rdr: ~T) -> Parser<T> {
+    fn new(rdr: Box<T>) -> Parser<T> {
         let mut p = Parser {
             ch: '\x00',
             line: 0,
@@ -127,10 +126,12 @@ impl<T: Iterator<char>> Parser<T> {
         p
     }
 
+    #[allow(unsigned_negate)]
     fn eof(&self) -> bool {
         self.ch == unsafe { transmute(-1u32) }
     }
 
+    #[allow(unsigned_negate)]
     fn bump(&mut self) {
         match self.rdr.next() {
             Some(ch) => self.ch = ch,
@@ -146,7 +147,7 @@ impl<T: Iterator<char>> Parser<T> {
         }
     }
 
-    fn error<T>(&self, msg: ~str) -> Result<T, Error> {
+    fn error<T>(&self, msg: String) -> Result<T, Error> {
         Err(Error { line: self.line, col: self.col, msg: msg.clone() })
     }
 
@@ -160,22 +161,22 @@ impl<T: Iterator<char>> Parser<T> {
     pub fn parse(&mut self) -> Result<Ini, Error> {
         self.parse_whitespace();
         let mut result = Ini::new();
-        let mut curkey = ~"";
-        let mut cursec = ~"";
+        let mut curkey: String = "".to_string();
+        let mut cursec: String = "".to_string();
         while !self.eof() {
             self.parse_whitespace();
-            debug!("line:%u, col:%u", self.line, self.col);
+            debug!("line:{}, col:{}", self.line, self.col);
             match self.ch {
-                ';' => { 
-                    self.parse_comment(); 
+                ';' => {
+                    self.parse_comment();
                     debug!("parse comment");
                 }
                 '[' => {
                     match self.parse_section() {
                         Ok(sec) => {
-                            let msec = sec.trim();
-                            debug!("Got section: %s", msec);
-                            cursec = msec.to_owned();
+                            let msec = sec.as_slice().trim();
+                            debug!("Got section: {}", msec);
+                            cursec = msec.to_string();
                             result.sections.find_or_insert(cursec.clone(), HashMap::new());
                             self.bump();
                         },
@@ -183,16 +184,16 @@ impl<T: Iterator<char>> Parser<T> {
                     };
                 }
                 '=' => {
-                    if curkey.char_len() == 0 {
-                        return self.error(~"Missing key");
+                    if curkey.as_slice().char_len() == 0 {
+                        return self.error("Missing key".to_string());
                     }
                     match self.parse_val() {
                         Ok(val) => {
-                            let mval = val.trim();
-                            debug!("Got value: %s", mval);
+                            let mval = val.as_slice().trim();
+                            debug!("Got value: {}", mval);
                             let sec = result.sections.find_mut(&cursec).unwrap();
-                            sec.insert_or_update_with(curkey, mval.to_owned(), |_,_| {});
-                            curkey = ~"";
+                            sec.insert_or_update_with(curkey, mval.to_string(), |_,_| {});
+                            curkey = "".to_string();
                             self.bump();
                         },
                         Err(e) => return Err(e),
@@ -201,9 +202,9 @@ impl<T: Iterator<char>> Parser<T> {
                 _ => {
                     match self.parse_key() {
                         Ok(key) => {
-                            let mkey = key.trim();
-                            debug!("Got key: %s", mkey);
-                            curkey = mkey.to_owned();
+                            let mkey = key.as_slice().trim();
+                            debug!("Got key: {}", mkey);
+                            curkey = mkey.to_string();
                         }
                         Err(e) => return Err(e),
                     }
@@ -219,8 +220,8 @@ impl<T: Iterator<char>> Parser<T> {
         if !self.eof() { self.bump(); }
     }
 
-    fn parse_str_until(&mut self, endpoint: char) -> Result<~str, Error> {
-        let mut result = ~"";
+    fn parse_str_until(&mut self, endpoint: char) -> Result<String, Error> {
+        let mut result: String = "".to_string();
         while self.ch != endpoint {
             if self.eof() {
                 return self.error(format!("Expecting \"{}\" but found EOF.", endpoint));
@@ -240,8 +241,8 @@ impl<T: Iterator<char>> Parser<T> {
                     '\n' => (),
                     'x' => {
                         // Unicode 4 char
-                        let mut code = ~"";
-                        for _ in range(0, 4) {
+                        let mut code: String = "".to_string();
+                        for _ in range(0u, 4u) {
                             self.bump();
                             if self.eof() {
                                 return self.error(format!("Expecting \"{}\" but found EOF.", endpoint));
@@ -254,10 +255,10 @@ impl<T: Iterator<char>> Parser<T> {
                             }
                             code.push_char(self.ch);
                         }
-                        let r : Option<u32> = from_str_radix(code, 16);
+                        let r : Option<u32> = from_str_radix(code.as_slice(), 16);
                         match r {
                             Some(c) => result.push_char(char::from_u32(c).unwrap()),
-                            None => return self.error(~"Unknown character.")
+                            None => return self.error("Unknown character.".to_string())
                         }
                     }
                     _ => result.push_char(self.ch)
@@ -271,95 +272,94 @@ impl<T: Iterator<char>> Parser<T> {
         Ok(result)
     }
 
-    fn parse_section(&mut self) -> Result<~str, Error> {
+    fn parse_section(&mut self) -> Result<String, Error> {
         // Skip [
         self.bump();
         self.parse_str_until(']')
     }
 
-    fn parse_key(&mut self) -> Result<~str, Error> {
+    fn parse_key(&mut self) -> Result<String, Error> {
         self.parse_str_until('=')
     }
 
-    fn parse_val(&mut self) -> Result<~str, Error> {
+    fn parse_val(&mut self) -> Result<String, Error> {
         self.bump();
         self.parse_str_until('\n')
     }
 }
 
 impl Ini {
-    pub fn load_from_str(buf : ~str) -> Ini {
-        let mut parser = Parser::new(~buf.iter());
+    pub fn load_from_str(buf: String) -> Ini {
+        let mut parser = Parser::new(box buf.as_slice().chars());
         match parser.parse() {
             Ok(ini) => ini,
             Err(e) => {
-                fail!("Parse fail. %u:%u %s", e.line, e.col, e.msg);
+                fail!("Parse fail. {}:{} {}", e.line, e.col, e.msg);
             }
         }
     }
 
     pub fn load_from_file(filename : &str) -> Ini {
-        let mut reader = match file::open(&Path(filename), Open, Read) {
-            None => {
-                fail!("File %s not exists", filename);
+        let mut reader = match File::open_mode(&Path::new(filename), Open, Read) {
+            Err(..) => {
+                fail!("File {} not exists", filename);
             }
-            Some(r) => r
+            Ok(r) => r
         };
         let mut mem = [0u8, ..10240];
-        let mut buf = ~"";
+        let mut buf: String = "".to_string();
 
         while !reader.eof() {
             let len = match reader.read(mem) {
-                Some(n) => n,
-                None => break
+                Ok(n) => n,
+                Err(..) => break
             };
 
-            buf.push_str(str::from_utf8(mem.slice_to(len)));
+            buf.push_str(str::from_utf8(mem.slice_to(len)).unwrap());
         }
-        Ini::load_from_str(buf) 
+        Ini::load_from_str(buf)
     }
 
     pub fn load_from_file_opt(filename : &str) -> Option<Ini> {
-        let mut reader = match file::open(&Path(filename), Open, Read) {
-            None => {
-                error!("File %s not exists", filename);
+        let mut reader = match File::open_mode(&Path::new(filename), Open, Read) {
+            Err(..) => {
+                error!("File {} not exists", filename);
                 return None;
             }
-            Some(r) => r
+            Ok(r) => r
         };
         let mut mem = [0u8, ..10240];
-        let mut buf = ~"";
+        let mut buf: String = "".to_string();
 
         while !reader.eof() {
             let len = match reader.read(mem) {
-                Some(n) => n,
-                None => break
+                Ok(n) => n,
+                Err(..) => break
             };
 
-            buf.push_str(str::from_utf8(mem.slice_to(len)));
+            buf.push_str(str::from_utf8(mem.slice_to(len)).unwrap());
         }
-        Ini::load_from_str_opt(buf) 
+        Ini::load_from_str_opt(buf)
     }
 
-    pub fn load_from_str_opt(buf : ~str) -> Option<Ini> {
-        let mut parser = Parser::new(~buf.iter());
+    pub fn load_from_str_opt(buf : String) -> Option<Ini> {
+        let mut parser = Parser::new(box buf.as_slice().chars());
         match parser.parse() {
             Ok(ini) => Some(ini),
             Err(e) => {
-                error!("Parse fail. %u:%u %s", e.line, e.col, e.msg);
+                error!("Parse fail. {}:{} {}", e.line, e.col, e.msg);
                 None
             }
         }
     }
 }
 
-#[deriving(Clone)]
-pub struct SectionIterator<'self> {
-    priv mapiter: HashMapIterator<'self, ~str, Properties>
+pub struct SectionIterator<'a> {
+    mapiter: Entries<'a, String, Properties>
 }
 
-pub struct SectionMutIterator<'self> {
-    priv mapiter: HashMapMutIterator<'self, ~str, Properties>
+pub struct SectionMutIterator<'a> {
+    mapiter: MutEntries<'a, String, Properties>
 }
 
 impl Ini {
@@ -367,21 +367,39 @@ impl Ini {
         SectionIterator { mapiter: self.sections.iter() }
     }
 
-    pub fn iter_mut<'a>(&'a mut self) -> SectionMutIterator<'a> {
+    pub fn mut_iter<'a>(&'a mut self) -> SectionMutIterator<'a> {
         SectionMutIterator { mapiter: self.sections.mut_iter() }
     }
 }
 
-impl<'self> Iterator<(&'self ~str, &'self Properties)> for SectionIterator<'self> {
+impl<'a> Iterator<(&'a String, &'a Properties)> for SectionIterator<'a> {
     #[inline]
-    fn next(&mut self) -> Option<(&'self ~str, &'self Properties)> {
+    fn next(&mut self) -> Option<(&'a String, &'a Properties)> {
         self.mapiter.next()
     }
 }
 
-impl<'self> Iterator<(&'self ~str, &'self mut Properties)> for SectionMutIterator<'self> {
+impl<'a> Iterator<(&'a String, &'a mut Properties)> for SectionMutIterator<'a> {
     #[inline]
-    fn next(&mut self) -> Option<(&'self ~str, &'self mut Properties)> {
+    fn next(&mut self) -> Option<(&'a String, &'a mut Properties)> {
         self.mapiter.next()
+    }
+}
+
+//------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod test {
+    use ini::*;
+
+    #[test]
+    fn load_from_str_opt_with_valid_input() {
+        let input = "[group1]\nkey1=val1\nkye2=377\n[group2]foo=bar\n".to_string();
+        let opt = Ini::load_from_str_opt(input);
+        assert!(opt.is_some());
+        let output = opt.unwrap();
+        assert_eq!(output.sections.len(), 2);
+        assert!(output.sections.contains_key(&"group1".to_string()));
+        assert!(output.sections.find(&"group1".to_string()));
     }
 }

--- a/src/libini/lib.rs
+++ b/src/libini/lib.rs
@@ -1,4 +1,10 @@
-#[link(name="ini", vers="0.1")];
+#![crate_id = "ini#0.2"]
+#![crate_type = "lib"]
+
+#![feature(globs)]
+#![feature(phase)]
+
+#[phase(plugin, link)] extern crate log;
 
 pub use ini::Ini;
 pub mod ini;

--- a/src/libini/test.rs
+++ b/src/libini/test.rs
@@ -1,4 +1,4 @@
-extern mod ini;
+extern crate ini;
 
 use ini::Ini;
 


### PR DESCRIPTION
Major changes:
1. ~str to String.
2. ~SomeType to Box<SomeType>.
3. `priv` is removed from the language.
4. Lifetime specifier 'self is removed from the language.
5. `extern mod` changed to `extern crate`.
6. Format specifiers changed to `{}`.
7. `std` lib functions related changes.
8. Other minor syntax changes. (like `#[...]` to `#![...]`)

Added:
- A simple unit test case. (build with `rustc --test ...`)
