### PR TITLE
Latest alpha compatability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ license = "MIT"
 [lib]
 name = "ini"
 test = true
+
+[dependencies]
+log = "*"

--- a/src/ini.rs
+++ b/src/ini.rs
@@ -22,11 +22,11 @@
 use std::collections::HashMap;
 use std::collections::hash_map::{Iter, IterMut, Keys};
 use std::collections::hash_map::Entry;
-use std::io::{File, Read, Open, Write, Truncate};
+use std::old_io::{File, Read, Open, Write, Truncate};
 use std::ops::{Index, IndexMut};
 use std::char;
 use std::num::from_str_radix;
-use std::io::{BufferedReader, MemReader, IoResult};
+use std::old_io::{BufferedReader, MemReader, IoResult};
 use std::fmt::{self, Display};
 
 fn escape_str(s: &str) -> String {
@@ -223,7 +223,7 @@ impl Ini {
                 firstline = false;
             }
             else {
-                try!(writer.write("\n".as_bytes()));
+                try!(writer.write_all("\n".as_bytes()));
             }
             try!(write!(writer, "[{}]\n", escape_str(section.as_slice())));
             for (k, v) in props.iter() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,11 @@
 //! }
 //! ```
 
-#![allow(unstable)]
+#![feature(collections)]
+#![feature(std_misc)]
+#![feature(io)]
+#![feature(core)]
+#![feature(path)]
 #[macro_use] extern crate log;
 
 pub use ini::Ini;


### PR DESCRIPTION
This catches up with the break out of log to a separate crate, the
rename of writer.write(), and the rename of std::io. The result is
a warning free build, but by disabling a bunch of unstable warnings,
rather than fixing code.