### PR TITLE
Modified Ini::write_to_file to create the file if it doesn't exist.

### DIFF
--- a/src/ini.rs
+++ b/src/ini.rs
@@ -250,7 +250,7 @@ impl<'q> IndexMut<&'q String> for Ini {
 
 impl Ini {
     pub fn write_to_file(&self, filename: &str) -> io::Result<()> {
-        let mut file = try!(OpenOptions::new().write(true).truncate(true).open(&Path::new(filename)));
+        let mut file = try!(OpenOptions::new().write(true).truncate(true).create(true).open(&Path::new(filename)));
         self.write_to(&mut file)
     }
 


### PR DESCRIPTION
Ini::write_to_file currently fails with an error if the file does not exist. Feel free to close if it is the intended behaviour.