### PR TITLE
Added escape controls

### DIFF
--- a/src/ini.rs
+++ b/src/ini.rs
@@ -136,6 +136,7 @@ impl<'a> SectionSetter<'a> {
 pub type Properties = HashMap<String, String>; // Key-value pairs
 
 /// Ini struct
+#[derive(Clone)]
 pub struct Ini {
     sections: HashMap<Option<String>, Properties>,
 }


### PR DESCRIPTION
This adds the ability to control what is being escaped and what is not. This
is necessary because most non windows INI libraries do not actually understand
most (or all) escape rules. It also sets the default escaping to restricted
characters only.

Note that this is branched off #23 which is why there are two commits in it.