### PR TITLE
Bump version number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-ini"
-version = "0.9.12"
+version = "0.10.0"
 authors = ["Y. T. Chung <zonyitoo@gmail.com>"]
 description = "An Ini configuration file parsing library in Rust"
 repository = "https://github.com/zonyitoo/rust-ini"


### PR DESCRIPTION
I upped the Minor version, as the PR I made the other day was a backwards compatible change that added functionality. Would you mind pushing the new version to crates.io?