### PR TITLE
Restore compatibility with Rust <1.26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rust:
     - nightly
     - beta
     - stable
+    - 1.15.0
 
 cache: cargo
 

--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,9 @@ This is an INI file parser in Rust_.
     [dependencies]
     rust-ini = "0.12"
 
+This crate currently supports Rust 1.15+. Changes in the minimally required Rust
+version will be treated as an incompatible change.
+
 Usage
 =====
 

--- a/src/ini.rs
+++ b/src/ini.rs
@@ -648,25 +648,25 @@ pub enum Error {
 
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match &self {
-            &Error::Io(err) => err.fmt(f),
-            &Error::Parse(err) => err.fmt(f),
+        match self {
+            &Error::Io(ref err) => err.fmt(f),
+            &Error::Parse(ref err) => err.fmt(f),
         }
     }
 }
 
 impl error::Error for Error {
     fn description(&self) -> &str {
-        match &self {
-            &Error::Io(err) => err.description(),
-            &Error::Parse(err) => err.description(),
+        match self {
+            &Error::Io(ref err) => err.description(),
+            &Error::Parse(ref err) => err.description(),
         }
     }
 
     fn cause(&self) -> Option<&error::Error> {
-        match &self {
-            &Error::Io(err) => err.cause(),
-            &Error::Parse(err) => err.cause(),
+        match self {
+            &Error::Io(ref err) => err.cause(),
+            &Error::Parse(ref err) => err.cause(),
         }
     }
 }


### PR DESCRIPTION
The changes in commit 40d16ef26 work on Rust 1.26 due to the way matches
are handled, but they break compatibility with older Rust versions.

By reverting to older syntax, the tests pass even with Rust 1.15.

This PR also contains an update to the TravisCI config to prevent this from happening again. It also contains a change to the README, stating that changes in the minimal required Rust version will be treated as backwards incompatible. @zonyitoo I hope that you agree with this :slightly_smiling_face: 