### PR TITLE
add feature: preserve_order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Cargo.lock
 
 .DS_Store
 Thumbs.db
+/.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,5 @@ cache: cargo
 
 script:
     - cargo test -v --no-fail-fast
+    - cargo test -v --no-fail-fast --features preserve_order
     - cargo doc --no-deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,8 @@ test = true
 
 [dependencies]
 multimap = "0.5.0"
+indexmap = { version = "1.3", optional = true }
+
+[features]
+default = []
+preserve_order = ["indexmap"]

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -16,9 +16,7 @@ fn main() {
         .set("name", "Sun Yat-sen U")
         .set("location", "Guangzhou=world\x0ahahaha");
 
-    conf.section_mut(Some("Library"))
-        .unwrap()
-        .insert("seats".into(), "42".into());
+    conf.section_mut(Some("Library")).unwrap().insert("seats", "42");
 
     println!("---------------------------------------");
     println!("Writing to file {:?}\n", CONF_FILE_NAME);

--- a/src/ini.rs
+++ b/src/ini.rs
@@ -230,18 +230,22 @@ pub struct Properties {
 }
 
 impl Properties {
+    /// Create an instance
     pub fn new() -> Properties {
         Default::default()
     }
 
+    /// Get the number of the properties
     pub fn len(&self) -> usize {
         self.data.len()
     }
 
+    /// Get an iterator of the properties
     pub fn iter(&self) -> impl Iterator<Item = (&String, &String)> {
         self.data.iter().map(|(k, v)| (k, v))
     }
 
+    /// Return true if property exist
     pub fn contains_key<S: AsRef<str>>(&self, s: S) -> bool {
         self.iter().find(|(k, _)| *k == s.as_ref()).is_some()
     }
@@ -249,6 +253,7 @@ impl Properties {
 
 #[cfg(not(feature = "preserve_order"))]
 impl Properties {
+    /// Insert (key, value) pair
     pub fn insert<K, V>(&mut self, k: K, v: V)
         where K: Into<String>,
               V: Into<String>
@@ -256,15 +261,18 @@ impl Properties {
         self.data.insert(k.into(), v.into());
     }
 
+    /// Get the first value associate with the key
     pub fn get<S: AsRef<str>>(&self, s: S) -> Option<&String> {
         self.data.get(s.as_ref())
     }
 
+    /// Get all values associate with the key
     pub fn get_vec<S: AsRef<str>>(&self, s: S) -> Option<Vec<&String>> {
         let ret = self.data.get_vec(s.as_ref())?.iter().collect();
         Some(ret)
     }
 
+    /// Remove the property
     pub fn remove<S: AsRef<str>>(&mut self, s: S) -> Option<Vec<String>> {
         self.data.remove(s.as_ref())
     }
@@ -272,11 +280,11 @@ impl Properties {
     fn get_mut<S: AsRef<str>>(&mut self, s: S) -> Option<&mut String> {
         self.data.get_mut(s.as_ref())
     }
-
 }
 
 #[cfg(feature = "preserve_order")]
 impl Properties {
+    /// Insert (key, value) pair
     pub fn insert<K, V>(&mut self, k: K, v: V)
         where K: Into<String>,
               V: Into<String>
@@ -284,6 +292,7 @@ impl Properties {
         self.data.push((k.into(), v.into()));
     }
 
+    /// Get the first value associate with the key
     pub fn get<S: AsRef<str>>(&self, s: S) -> Option<&String> {
         for (k, v) in &self.data {
             if k == s.as_ref() {
@@ -293,6 +302,7 @@ impl Properties {
         None
     }
 
+    /// Get all values associate with the key
     pub fn get_vec<S: AsRef<str>>(&self, s: S) -> Option<Vec<&String>> {
         let ret: Vec<_> = self.data
                               .iter()
@@ -307,6 +317,7 @@ impl Properties {
         }
     }
 
+    /// Remove the property
     pub fn remove<S: AsRef<str>>(&mut self, s: S) -> Option<Vec<String>> {
         let len = self.data.len();
         let mut data = Vec::with_capacity(len);

--- a/src/ini.rs
+++ b/src/ini.rs
@@ -265,13 +265,14 @@ impl Properties {
         Some(ret)
     }
 
-    pub fn get_mut<S: AsRef<str>>(&mut self, s: S) -> Option<&mut String> {
-        self.data.get_mut(s.as_ref())
-    }
-
     pub fn remove<S: AsRef<str>>(&mut self, s: S) -> Option<Vec<String>> {
         self.data.remove(s.as_ref())
     }
+
+    fn get_mut<S: AsRef<str>>(&mut self, s: S) -> Option<&mut String> {
+        self.data.get_mut(s.as_ref())
+    }
+
 }
 
 #[cfg(feature = "preserve_order")]
@@ -306,15 +307,6 @@ impl Properties {
         }
     }
 
-    pub fn get_mut<S: AsRef<str>>(&mut self, s: S) -> Option<&mut String> {
-        for (k, v) in &mut self.data {
-            if k == s.as_ref() {
-                return Some(v);
-            }
-        }
-        None
-    }
-
     pub fn remove<S: AsRef<str>>(&mut self, s: S) -> Option<Vec<String>> {
         let len = self.data.len();
         let mut data = Vec::with_capacity(len);
@@ -335,6 +327,15 @@ impl Properties {
         } else {
             Some(ret)
         }
+    }
+
+    fn get_mut<S: AsRef<str>>(&mut self, s: S) -> Option<&mut String> {
+        for (k, v) in &mut self.data {
+            if k == s.as_ref() {
+                return Some(v);
+            }
+        }
+        None
     }
 }
 
@@ -1024,6 +1025,18 @@ mod test {
 
         let res = props.get_vec("k2");
         assert_eq!(res, None);
+    }
+
+    #[test]
+    fn test_property_remove() {
+        let mut props = Properties::new();
+        props.insert("k1", "v1");
+        props.insert("k1", "v2");
+
+        let mut res = props.remove("k1").unwrap();
+        res.sort();
+        assert_eq!(res, vec!["v1", "v2"]);
+        assert!(!props.contains_key("k1"));
     }
 
     #[test]

--- a/src/ini.rs
+++ b/src/ini.rs
@@ -260,6 +260,11 @@ impl Properties {
         self.data.get(s.as_ref())
     }
 
+    pub fn get_vec<S: AsRef<str>>(&self, s: S) -> Option<Vec<&String>> {
+        let ret = self.data.get_vec(s.as_ref())?.iter().collect();
+        Some(ret)
+    }
+
     pub fn get_mut<S: AsRef<str>>(&mut self, s: S) -> Option<&mut String> {
         self.data.get_mut(s.as_ref())
     }
@@ -285,6 +290,20 @@ impl Properties {
             }
         }
         None
+    }
+
+    pub fn get_vec<S: AsRef<str>>(&self, s: S) -> Option<Vec<&String>> {
+        let ret: Vec<_> = self.data
+                              .iter()
+                              .filter(|(k, _)| k == s.as_ref())
+                              .map(|(_, v)| v)
+                              .collect();
+
+        if ret.is_empty() {
+            None
+        } else {
+            Some(ret)
+        }
     }
 
     pub fn get_mut<S: AsRef<str>>(&mut self, s: S) -> Option<&mut String> {
@@ -992,6 +1011,20 @@ impl<'a> Parser<'a> {
 #[cfg(test)]
 mod test {
     use ini::*;
+
+    #[test]
+    fn test_property_get_vec() {
+        let mut props = Properties::new();
+        props.insert("k1", "v1");
+        props.insert("k1", "v2");
+
+        let mut res = props.get_vec("k1").unwrap();
+        res.sort();
+        assert_eq!(res, vec!["v1", "v2"]);
+
+        let res = props.get_vec("k2");
+        assert_eq!(res, None);
+    }
 
     #[test]
     fn load_from_str_with_valid_input() {

--- a/src/ini.rs
+++ b/src/ini.rs
@@ -85,9 +85,9 @@ impl EscapePolicy {
     /// per this policy or false if not.
     pub fn should_escape(self, c: char) -> bool {
         match c {
-            '\\' | '\x00'...'\x1f' | '\x7f'...'\u{00ff}' => self.escape_basics(),
+            '\\' | '\x00'..='\x1f' | '\x7f'..='\u{00ff}' => self.escape_basics(),
             ';' | '#' | '=' | ':' => self.escape_reserved(),
-            '\u{0080}'...'\u{FFFF}' => self.escape_unicode(),
+            '\u{0080}'..='\u{FFFF}' => self.escape_unicode(),
             _ => false,
         }
     }
@@ -122,7 +122,7 @@ fn escape_str(s: &str, policy: EscapePolicy) -> String {
         match c {
             '\\' => escaped.push_str("\\\\"),
             '\0' => escaped.push_str("\\0"),
-            '\x01'...'\x06' | '\x0e'...'\x1f' | '\x7f'...'\u{00ff}' => {
+            '\x01'..='\x06' | '\x0e'..='\x1f' | '\x7f'..='\u{00ff}' => {
                 escaped.push_str(&format!("\\x{:04x}", c as isize)[..])
             }
             '\x07' => escaped.push_str("\\a"),
@@ -132,7 +132,7 @@ fn escape_str(s: &str, policy: EscapePolicy) -> String {
             '\n' => escaped.push_str("\\n"),
             '\t' => escaped.push_str("\\t"),
             '\r' => escaped.push_str("\\r"),
-            '\u{0080}'...'\u{FFFF}' => escaped.push_str(&format!("\\x{:04x}", c as isize)[..]),
+            '\u{0080}'..='\u{FFFF}' => escaped.push_str(&format!("\\x{:04x}", c as isize)[..]),
             _ => {
                 escaped.push('\\');
                 escaped.push(c);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,9 @@
 //! }
 //! ```
 
+#[cfg(feature = "preserve_order")]
+extern crate indexmap;
+#[cfg(not(feature = "preserve_order"))]
 extern crate multimap;
 
 pub use ini::{Ini, ParseOption};


### PR DESCRIPTION
Some system relies on the order of the properties,  e.g. [pacman.conf](https://www.archlinux.org/pacman/pacman.conf.5.html)