### PR TITLE
Remove deprecated Error::description and Error::cause 

### DIFF
--- a/src/ini.rs
+++ b/src/ini.rs
@@ -764,15 +764,7 @@ impl Display for ParseError {
     }
 }
 
-impl error::Error for ParseError {
-    fn description(&self) -> &str {
-        self.msg.as_str()
-    }
-
-    fn cause(&self) -> Option<&dyn error::Error> {
-        None
-    }
-}
+impl error::Error for ParseError {}
 
 #[derive(Debug)]
 pub enum Error {
@@ -790,13 +782,6 @@ impl Display for Error {
 }
 
 impl error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::Io(ref err) => err.description(),
-            Error::Parse(ref err) => err.description(),
-        }
-    }
-
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             Error::Io(ref err) => err.source(),


### PR DESCRIPTION
`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon. `Error::cause` has been documented as deprecated since 1.27.0 .

This PR:
- Removes all implementations of `description` and `cause` in all error types

Related PR: https://github.com/rust-lang/rust/pull/66919