### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Usage
 
     fn main() {
         let mut conf = Ini::new();
-        conf.with_section(None)
+        conf.with_section(None::<String>)
             .set("encoding", "utf-8");
         conf.with_section(Some("User"))
             .set("given_name", "Tommy")


### PR DESCRIPTION
fixed this error:
error[E0283]: type annotations needed
  --> src\main.rs:10:10
   |
10 |     conf.with_section(None).set("encoding", "utf-8");
   |          ^^^^^^^^^^^^ cannot infer type for type parameter `S` declared on the associated function `with_section`
   |
   = note: cannot satisfy `_: std::convert::Into<std::string::String>`

error: aborting due to previous error