### PR TITLE
Cargo: bump ordered-multimap to ^0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ test = true
 [dependencies]
 cfg-if = "0.1"
 unicase = { version = "2.6", optional = true }
-ordered-multimap = "0.2"
+ordered-multimap = "0.3"
 
 [features]
 default = []


### PR DESCRIPTION
Updating this dependency required no code changes.
Executing tests locally with `cargo test` and `cargo test --all-features` was successful.