### PR TITLE
Implement Iterator::size_hint method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -869,6 +869,10 @@ impl<'a> Iterator for SectionIter<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next().map(|(k, v)| (k.as_ref().map(|s| s.as_str()), v))
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
 }
 
 /// Iterator for traversing sections
@@ -881,6 +885,10 @@ impl<'a> Iterator for SectionIterMut<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next().map(|(k, v)| (k.as_ref().map(|s| s.as_str()), v))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
     }
 }
 


### PR DESCRIPTION
This allows to optimize some iterator-related methods like `.collect()` in some case.