### PR TITLE
Add #[deprecated] attribute to Ini::mut_iter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -891,7 +891,7 @@ impl<'a> Ini {
     }
 
     /// Mutable iterate though sections
-    /// *Deprecated! Use `iter_mut` instead!*
+    #[deprecated(note = "Use `iter_mut` instead!")]
     pub fn mut_iter(&'a mut self) -> SectionIterMut<'a> {
         self.iter_mut()
     }


### PR DESCRIPTION
The docs have already said that this method is deprecated, but the user will not aware that it is deprecated unless they read the docs.
`#[deprecated]` attribute is more noticeable because it emits a warning when the user uses it.
