### PR TITLE
Fix reported line/column numbers in error message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1045,8 +1045,8 @@ impl<'a> Parser<'a> {
     }
 
     fn error<U, M: Into<String>>(&self, msg: M) -> Result<U, ParseError> {
-        Err(ParseError { line: self.line,
-                         col: self.col,
+        Err(ParseError { line: self.line + 1,
+                         col: self.col + 1,
                          msg: msg.into() })
     }
 


### PR DESCRIPTION
The numbers (in common sense) start counting from 1, not 0.
This can be seen in a few editors, such as: Sublime Text, VS Code, Notepad++.