### PR TITLE
Add support for custom key-value separator in nameless sections.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -810,7 +810,7 @@ impl Ini {
             for (k, v) in props.iter() {
                 let k_str = escape_str(k, opt.escape_policy);
                 let v_str = escape_str(v, opt.escape_policy);
-                write!(writer, "{}={}{}", k_str, v_str, opt.line_separator)?;
+                write!(writer, "{}{}{}{}", k_str, opt.kv_separator, v_str, opt.line_separator)?;
 
                 firstline = false;
             }
@@ -2119,6 +2119,9 @@ a3 = n3
         use std::str;
 
         let mut ini = Ini::new();
+        ini.with_section(None::<String>)
+            .set("Key1", "Value")
+            .set("Key2", "Value");
         ini.with_section(Some("Section1"))
             .set("Key1", "Value")
             .set("Key2", "Value");
@@ -2139,12 +2142,12 @@ a3 = n3
         // Test different line endings in Windows and Unix
         if cfg!(windows) {
             assert_eq!(
-                "[Section1]\r\nKey1 = Value\r\nKey2 = Value\r\n\r\n[Section2]\r\nKey1 = Value\r\nKey2 = Value\r\n",
+                "Key1 = Value\r\nKey2 = Value\r\n\r\n[Section1]\r\nKey1 = Value\r\nKey2 = Value\r\n\r\n[Section2]\r\nKey1 = Value\r\nKey2 = Value\r\n",
                 str::from_utf8(&buf).unwrap()
             );
         } else {
             assert_eq!(
-                "[Section1]\nKey1 = Value\nKey2 = Value\n\n[Section2]\nKey1 = Value\nKey2 = Value\n",
+                "Key1 = Value\nKey2 = Value\n\n[Section1]\nKey1 = Value\nKey2 = Value\n\n[Section2]\nKey1 = Value\nKey2 = Value\n",
                 str::from_utf8(&buf).unwrap()
             );
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -806,37 +806,28 @@ impl Ini {
     pub fn write_to_opt<W: Write>(&self, writer: &mut W, opt: WriteOption) -> io::Result<()> {
         let mut firstline = true;
 
-        if let Some(props) = self.sections.get(&None) {
-            for (k, v) in props.iter() {
-                let k_str = escape_str(k, opt.escape_policy);
-                let v_str = escape_str(v, opt.escape_policy);
-                write!(writer, "{}{}{}{}", k_str, opt.kv_separator, v_str, opt.line_separator)?;
-
-                firstline = false;
-            }
-        }
-
         for (section, props) in &self.sections {
-            if let Some(ref section) = *section {
+            if !props.data.is_empty() {
                 if firstline {
                     firstline = false;
                 } else {
                     // Write an empty line between sections
                     writer.write_all(opt.line_separator.as_str().as_bytes())?;
                 }
+            }
 
+            if let Some(ref section) = *section {
                 write!(
                     writer,
                     "[{}]{}",
                     escape_str(&section[..], opt.escape_policy),
                     opt.line_separator
                 )?;
-
-                for (k, v) in props.iter() {
-                    let k_str = escape_str(k, opt.escape_policy);
-                    let v_str = escape_str(v, opt.escape_policy);
-                    write!(writer, "{}{}{}{}", k_str, opt.kv_separator, v_str, opt.line_separator)?;
-                }
+            }
+            for (k, v) in props.iter() {
+                let k_str = escape_str(k, opt.escape_policy);
+                let v_str = escape_str(v, opt.escape_policy);
+                write!(writer, "{}{}{}{}", k_str, opt.kv_separator, v_str, opt.line_separator)?;
             }
         }
         Ok(())


### PR DESCRIPTION
Per the title, it seems that this area got missed when the functionality was added.