### PR TITLE
Add inline(never) to Parser::error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1243,6 +1243,8 @@ impl<'a> Parser<'a> {
         }
     }
 
+    #[cold]
+    #[inline(never)]
     fn error<U, M: Into<Cow<'static, str>>>(&self, msg: M) -> Result<U, ParseError> {
         Err(ParseError {
             line: self.line + 1,


### PR DESCRIPTION
This reduces code size a little bit, and should improve codegen, as the error path is pessimised 