### PR TITLE
Avoid reallocating for trimming

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ test = true
 cfg-if = "1.0"
 unicase = { version = "2.6", optional = true }
 ordered-multimap = "0.7"
+trim-in-place = "0.1.7"
 
 [features]
 default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ use ordered_multimap::{
     list_ordered_multimap::{Entry, IntoIter, Iter, IterMut, OccupiedEntry, VacantEntry},
     ListOrderedMultimap,
 };
+use trim_in_place::TrimInPlace;
 #[cfg(feature = "case-insensitive")]
 use unicase::UniCase;
 
@@ -1293,9 +1294,9 @@ impl<'a> Parser<'a> {
                     self.parse_comment();
                 }
                 '[' => match self.parse_section() {
-                    Ok(sec) => {
-                        let msec = sec[..].trim();
-                        cursec = Some((*msec).to_string());
+                    Ok(mut sec) => {
+                        sec.trim_in_place();
+                        cursec = Some(sec);
                         match result.entry(cursec.clone()) {
                             SectionEntry::Vacant(v) => {
                                 v.insert(Default::default());
@@ -1312,8 +1313,8 @@ impl<'a> Parser<'a> {
                         return self.error("missing key");
                     }
                     match self.parse_val() {
-                        Ok(val) => {
-                            let mval = val[..].trim().to_owned();
+                        Ok(mut mval) => {
+                            mval.trim_in_place();
                             match result.entry(cursec.clone()) {
                                 SectionEntry::Vacant(v) => {
                                     // cursec must be None (the General Section)
@@ -1332,8 +1333,8 @@ impl<'a> Parser<'a> {
                     }
                 }
                 _ => match self.parse_key() {
-                    Ok(key) => {
-                        let mkey: String = key[..].trim().to_owned();
+                    Ok(mut mkey) => {
+                        mkey.trim_in_place();
                         curkey = mkey;
                     }
                     Err(e) => return Err(e),


### PR DESCRIPTION
Replaces the inefficient `.trim().to_owned()` with a small dependency which doesn't reallocate.