### PR TITLE
Updating README usage version to 0.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is an INI file parser in [Rust](http://www.rust-lang.org/).
 
 ```toml
 [dependencies]
-rust-ini = "0.19"
+rust-ini = "0.20"
 ```
 
 ## Usage


### PR DESCRIPTION
README version shows version `0.19` when `0.20` is available. Simple update.