### PR TITLE
feat(fmt): support fmt::Writers when writing ini to a Writer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2702,7 +2702,10 @@ x1 = na
 x3 = nb
 ";
         let data = Ini::load_from_str(input).unwrap();
-        let exp = "x2=nc\nx1=na\nx3=nb\n";
+        let exp = r"x2=nc
+x1=na
+x3=nb
+";
         assert_eq!(data.to_string(), exp);
         let mut my_str = String::new();
         let _ = data.write_to_fmt(&mut my_str);


### PR DESCRIPTION
Allows for

```rust
ini.to_string()
ini.write_to_fmt(&mut std::fmt::Writer)
ini.write_to_policy_fmt(&mut std::fmt::Writer, EscapePolicy)
ini.write_to_opt_fmt(&mut std::fmt::Write, WriteOption)
```

## Context

I'm working with a very laggy remote Windows file system. Each individual R/W request has about 2 seconds delay before actually getting serviced. This means the streaming `write!`-based implementation of `write_to_opt()` is resulting in something like an O(n) slow-down where n is the # lines in the file. Introducing a `fmt::Writer` version, `write_to_opt_fmt`, lets me buffer the entire ini as a `String` and then fire it in one shot, resulting in a 75x performance improvement in my test scenario with an INI 462 lines long.