### PR TITLE
Feat:read section from multiple files;meger and override key value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1033,29 +1033,29 @@ impl Ini {
     /// Load from files;overwrite and append
     #[cfg(feature = "case-insensitive")]
     pub fn load_from_files<P: AsRef<Path>>(filenames: &Vec<P>) -> Result<Ini, Error> {
-    let mut merged = Ini::new();
-    let mut section_2_props: HashMap<Option<UniCase<String>>, Properties> = HashMap::new();
-    for filename in filenames {
-        match Ini::load_from_file(filename) {
-            Ok(ini) => {
-                for (section, props) in ini.sections {
-                    if let Some(section_props) = section_2_props.get_mut(&section) {
-                        for (key, value) in props {
-                            section_props.insert(key, value);
+        let mut merged = Ini::new();
+        let mut section_2_props: HashMap<Option<UniCase<String>>, Properties> = HashMap::new();
+        for filename in filenames {
+            match Ini::load_from_file(filename) {
+                Ok(ini) => {
+                    for (section, props) in ini.sections {
+                        if let Some(section_props) = section_2_props.get_mut(&section) {
+                            for (key, value) in props {
+                                section_props.insert(key, value);
+                            }
+                        } else {
+                            section_2_props.insert(section, props);
                         }
-                    } else {
-                        section_2_props.insert(section, props);
                     }
                 }
+                Err(e) => return Err(e),
             }
-            Err(e) => return Err(e),
         }
+        for (section, props) in section_2_props {
+            merged.sections.insert(section, props);
+        }
+        Ok(merged)
     }
-    for (section, props) in section_2_props {
-        merged.sections.insert(section, props);
-    }
-    Ok(merged)
-}
 
     /// Load from a file, but do not interpret '\' as an escape character
     pub fn load_from_file_noescape<P: AsRef<Path>>(filename: P) -> Result<Ini, Error> {
@@ -2847,7 +2847,7 @@ bla = a
             file.write_all(file_content2.as_bytes()).expect("write");
         }
 
-        let inifiles = vec![&file_name1,&file_name2];
+        let inifiles = vec![&file_name1, &file_name2];
         let ini = Ini::load_from_files(&inifiles).unwrap();
         assert_eq!(ini.get_from(Some("Test"), "Key"), Some("Value2"));
         assert_eq!(ini.get_from(Some("Test"), "Key2"), Some("Value3"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1057,6 +1057,32 @@ impl Ini {
         Ok(merged)
     }
 
+    #[cfg(not(feature = "case-insensitive"))]
+    pub fn load_from_files<P: AsRef<Path>>(filenames: &Vec<P>) -> Result<Ini, Error> {
+        let mut merged = Ini::new();
+        let mut section_2_props: HashMap<Option<String>, Properties> = HashMap::new();
+        for filename in filenames {
+            match Ini::load_from_file(filename) {
+                Ok(ini) => {
+                    for (section, props) in ini.sections {
+                        if let Some(section_props) = section_2_props.get_mut(&section) {
+                            for (key, value) in props {
+                                section_props.insert(key, value);
+                            }
+                        } else {
+                            section_2_props.insert(section, props);
+                        }
+                    }
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        for (section, props) in section_2_props {
+            merged.sections.insert(section, props);
+        }
+        Ok(merged)
+    }
+
     /// Load from a file, but do not interpret '\' as an escape character
     pub fn load_from_file_noescape<P: AsRef<Path>>(filename: P) -> Result<Ini, Error> {
         Ini::load_from_file_opt(
@@ -2826,7 +2852,6 @@ bla = a
     }
 
     #[test]
-    #[cfg(feature = "case-insensitive")]
     fn test_load_from_files() {
         //Test both overwrite and append
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1031,30 +1031,31 @@ impl Ini {
     }
 
     /// Load from files;overwrite and append
+    #[cfg(feature = "case-insensitive")]
     pub fn load_from_files<P: AsRef<Path>>(filenames: &Vec<P>) -> Result<Ini, Error> {
-        let mut merged = Ini::new();
-        let mut section_2_props: HashMap<Option<String>, Properties> = HashMap::new();
-        for filename in filenames {
-            match Ini::load_from_file(filename) {
-                Ok(ini) => {
-                    for (section, props) in ini.sections {
-                        if let Some(section_props) = section_2_props.get_mut(&section) {
-                            for (key, value) in props {
-                                section_props.insert(key, value);
-                            }
-                        } else {
-                            section_2_props.insert(section, props);
+    let mut merged = Ini::new();
+    let mut section_2_props: HashMap<Option<UniCase<String>>, Properties> = HashMap::new();
+    for filename in filenames {
+        match Ini::load_from_file(filename) {
+            Ok(ini) => {
+                for (section, props) in ini.sections {
+                    if let Some(section_props) = section_2_props.get_mut(&section) {
+                        for (key, value) in props {
+                            section_props.insert(key, value);
                         }
+                    } else {
+                        section_2_props.insert(section, props);
                     }
                 }
-                Err(e) => return Err(e),
             }
+            Err(e) => return Err(e),
         }
-        for (section, props) in section_2_props {
-            merged.sections.insert(section, props);
-        }
-        Ok(merged)
     }
+    for (section, props) in section_2_props {
+        merged.sections.insert(section, props);
+    }
+    Ok(merged)
+}
 
     /// Load from a file, but do not interpret '\' as an escape character
     pub fn load_from_file_noescape<P: AsRef<Path>>(filename: P) -> Result<Ini, Error> {
@@ -2825,6 +2826,7 @@ bla = a
     }
 
     #[test]
+    #[cfg(feature = "case-insensitive")]
     fn test_load_from_files() {
         //Test both overwrite and append
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,14 +44,15 @@
 
 use std::{
     borrow::Cow,
-    char, error,
+    char,
+    collections::HashMap,
+    error,
     fmt::{self, Display},
     fs::{File, OpenOptions},
     io::{self, Read, Seek, SeekFrom, Write},
     ops::{Index, IndexMut},
     path::Path,
     str::Chars,
-    collections::HashMap,
 };
 
 use cfg_if::cfg_if;
@@ -1030,10 +1031,10 @@ impl Ini {
     }
 
     /// Load from files;overwrite and append
-    pub fn load_from_files<P: AsRef<Path>>(filenames: Vec<P>) -> Result<Ini, Error> {
+    pub fn load_from_files<P: AsRef<Path>>(filenames: &Vec<P>) -> Result<Ini, Error> {
         let mut merged = Ini::new();
-        let mut section_2_props:HashMap<Option<String>, Properties> = HashMap::new();
-        for filename in filenames{
+        let mut section_2_props: HashMap<Option<String>, Properties> = HashMap::new();
+        for filename in filenames {
             match Ini::load_from_file(filename) {
                 Ok(ini) => {
                     for (section, props) in ini.sections {
@@ -1053,9 +1054,7 @@ impl Ini {
             merged.sections.insert(section, props);
         }
         Ok(merged)
-        //Ini::load_from_file_opt(filename, ParseOption::default())
     }
-
 
     /// Load from a file, but do not interpret '\' as an escape character
     pub fn load_from_file_noescape<P: AsRef<Path>>(filename: P) -> Result<Ini, Error> {
@@ -1609,7 +1608,7 @@ impl<'a> Parser<'a> {
                     }
                     Some('\n') => {
                         val.push('\n');
-                        continue
+                        continue;
                     }
                     _ => break,
                 }
@@ -2846,9 +2845,9 @@ bla = a
             file.write_all(file_content2.as_bytes()).expect("write");
         }
 
-        let ini = Ini::load_from_files(vec![&file_name1, &file_name2]).unwrap();
+        let inifiles = vec![&file_name1,&file_name2];
+        let ini = Ini::load_from_files(&inifiles).unwrap();
         assert_eq!(ini.get_from(Some("Test"), "Key"), Some("Value2"));
         assert_eq!(ini.get_from(Some("Test"), "Key2"), Some("Value3"));
     }
-
 }


### PR DESCRIPTION
In my project, I have several subprocesses, and most of the .ini configurations are shared among them, with only a small portion being different. 
Therefore, I need to read two configuration files, one of which is shared, and the other is used to correspond to the different configurations for each subprocess.
 So the requirement is to read multiple configuration files, where a section may be configured by multiple files, and the configurations in the later files can override those in the earlier files. 
This is the reason for my pull request (PR) this time.