### PR TITLE
Remove the trim-in-place dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ test = true
 cfg-if = "1.0"
 unicase = { version = "2.6", optional = true }
 ordered-multimap = "0.7"
-trim-in-place = "0.1.7"
 
 [features]
 default = []


### PR DESCRIPTION
There's doesn't seem to be a good reason to use a library that uses unsafe code (though it seems sound to me) to accomplish something that can be done in a few calls to safe standard library functions.

I compared the optimised assembly generated by both approaches in the Rust Playground and the replacement is actually a bit simpler.